### PR TITLE
Suppress warnings in SSH

### DIFF
--- a/assets/lagoon.site.yml
+++ b/assets/lagoon.site.yml
@@ -4,5 +4,5 @@
     files: files
   user: ${env-name}
   ssh:
-    options: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 32222'
+    options: '-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=FATAL -p 32222'
     tty: false


### PR DESCRIPTION
Otherwise you see this message when connecting to a remote environment

```
> > Warning: Permanently added '[ssh.lagoon.amazeeio.cloud]:32222,[5.102.15.13]:32222' (ECDSA) to the list of known hosts.
```