### PR TITLE
Feature - support multiple DB types

### DIFF
--- a/assets/settings.lagoon.php
+++ b/assets/settings.lagoon.php
@@ -31,13 +31,14 @@ if (!defined("LAGOON_VERSION")) {
 
 // Lagoon database connection.
 if (getenv('LAGOON')) {
+  $dbtype = !empty(getenv('POSTGRES_HOST')) ? 'pgsql' : 'mysql';
   $databases['default']['default'] = [
-    'driver' => 'mysql',
-    'database' => getenv('MARIADB_DATABASE') ?: 'drupal',
-    'username' => getenv('MARIADB_USERNAME') ?: 'drupal',
-    'password' => getenv('MARIADB_PASSWORD') ?: 'drupal',
-    'host' => getenv('MARIADB_HOST') ?: 'mariadb',
-    'port' => getenv('MARIADB_PORT') ?: 3306,
+    'driver' => $dbtype,
+    'database' => getenv('POSTGRES_DATABASE') ?: getenv('MARIADB_DATABASE') ?: 'drupal',
+    'username' => getenv('POSTGRES_USERNAME') ?: getenv('MARIADB_USERNAME') ?: 'drupal',
+    'password' => getenv('POSTGRES_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
+    'host' => getenv('POSTGRES_HOST') ?: getenv('MARIADB_HOST') ?: 'mariadb',
+    'port' => $dbtype == 'pgsql' ? 5432 : getenv('MARIADB_PORT') ?: 3306,
     'prefix' => '',
   ];
 }

--- a/assets/settings.lagoon.php
+++ b/assets/settings.lagoon.php
@@ -37,8 +37,8 @@ if (getenv('LAGOON')) {
     'database' => getenv('POSTGRES_DATABASE') ?: getenv('MARIADB_DATABASE') ?: 'drupal',
     'username' => getenv('POSTGRES_USERNAME') ?: getenv('MARIADB_USERNAME') ?: 'drupal',
     'password' => getenv('POSTGRES_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
-    'host' => getenv('POSTGRES_HOST') ?: getenv('MARIADB_HOST') ?: 'mariadb',
-    'port' => $dbtype == 'pgsql' ? 5432 : getenv('MARIADB_PORT') ?: 3306,
+    'host' => getenv('POSTGRES_HOST') ?: (getenv('MARIADB_HOST') ?: 'mariadb'),
+    'port' => $dbtype == 'pgsql' ? 5432 : (getenv('MARIADB_PORT') ?: 3306),
     'prefix' => '',
   ];
 }

--- a/assets/settings.lagoon.php
+++ b/assets/settings.lagoon.php
@@ -31,16 +31,48 @@ if (!defined("LAGOON_VERSION")) {
 
 // Lagoon database connection.
 if (getenv('LAGOON')) {
-  $dbtype = !empty(getenv('POSTGRES_HOST')) ? 'pgsql' : 'mysql';
-  $databases['default']['default'] = [
-    'driver' => $dbtype,
-    'database' => getenv('POSTGRES_DATABASE') ?: getenv('MARIADB_DATABASE') ?: 'drupal',
-    'username' => getenv('POSTGRES_USERNAME') ?: getenv('MARIADB_USERNAME') ?: 'drupal',
-    'password' => getenv('POSTGRES_PASSWORD') ?: getenv('MARIADB_PASSWORD') ?: 'drupal',
-    'host' => getenv('POSTGRES_HOST') ?: (getenv('MARIADB_HOST') ?: 'mariadb'),
-    'port' => $dbtype == 'pgsql' ? 5432 : (getenv('MARIADB_PORT') ?: 3306),
-    'prefix' => '',
-  ];
+  $dbtype = getenv("DB_TYPE") ?: (!empty(getenv('POSTGRES_HOST')) ? 'pgsql' : 'mysql');
+
+  switch ($dbtype) {
+    case ('pgsql'):
+      $databases['default']['default'] = [
+        'driver' => 'pgsql',
+        'database' => getenv('POSTGRES_DATABASE') ?: 'drupal',
+        'username' => getenv('POSTGRES_USERNAME') ?: 'drupal',
+        'password' => getenv('POSTGRES_PASSWORD') ?: 'drupal',
+        'host' => getenv('POSTGRES_HOST') ?: 'postgresql',
+        'port' => $dbtype == 'pgsql' ? 5432 : (getenv('MARIADB_PORT') ?: 3306),
+        'prefix' => '',
+      ];
+      break;
+
+    case ('mysql'):
+      $databases['default']['default'] = [
+        'driver' => $dbtype,
+        'database' => getenv('MYSQL_DATABASE') ?: (getenv('MARIADB_DATABASE') ?: 'lagoon'),
+        'username' => getenv('MYSQL_USERNAME') ?: (getenv('MARIADB_USERNAME') ?: 'lagoon'),
+        'password' => getenv('MYSQL_PASSWORD') ?: (getenv('MARIADB_PASSWORD') ?: 'lagoon'),
+        'host' => getenv('MYSQL_HOST') ?: (getenv('MARIADB_HOST' ?: 'mysql')),
+        'port' => getenv('MYSQL_PORT') ?: (getenv('MARIADB_PORT') ?: 3306),
+        'prefix' => '',
+      ];
+      break;
+
+    case ('mariadb'):
+      // Fall through to default mariadb settings.
+    default:
+      // We default to the mariadb settings.
+      $databases['default']['default'] = [
+        'driver' => $dbtype,
+        'database' => getenv('MARIADB_DATABASE') ?: 'drupal',
+        'username' => getenv('MARIADB_USERNAME') ?: 'drupal',
+        'password' => getenv('MARIADB_PASSWORD') ?: 'drupal',
+        'host' => (getenv('MARIADB_HOST') ?: 'mariadb'),
+        'port' => getenv('MARIADB_PORT') ?: 3306,
+        'prefix' => '',
+      ];
+      break;
+  }
 }
 
 // Lagoon reverse proxy settings.


### PR DESCRIPTION
This draft seeks to introduce supporting multiple database types out of the box.

It makes the following assumptions/attempts the following:

- The most basic/default setup is the current one, namely a mariadb-drupal lagoon image (such as `uselagoon/mariadb-10.5-drupal`)
- If one wishes to distinguish between a database, we use the `DATABASE_TYPE` environment variable, which is assumed to be either `postgres`, `mysql`, or `mariadb`
- Based on these types, we take our best guess at what the defaults for that DATABASE_TYPE is.