### PR TITLE
Update annotations to PHP8 attributes

### DIFF
--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -278,6 +278,13 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
   private function isLagoonEnvironment() {
     return !empty(getenv("LAGOON"));
   }
+
+  /**
+   * This should be run before any Lagoon commands.
+   * Checks whether we have a valid environment before running.
+   *
+   * @return void
+   */
   private function preCommandChecks() {
     if($this->isLagoonEnvironment() == FALSE) {
       throw new CommandFailedException(dt("Attempting to run a Lagoon command in a non-Lagoon environment."));

--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -4,6 +4,7 @@ namespace Drush\Commands\drupal_integrations;
 
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Commands\DrushCommands;
+use Drush\Exceptions\CommandFailedException;
 use Drush\Drush;
 use Drush\Exceptions\CommandFailedException;
 use Drush\SiteAlias\SiteAliasManagerAwareInterface;

--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -3,6 +3,7 @@
 namespace Drush\Commands\drupal_integrations;
 
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
+use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Drush\Drush;
 use Drush\Exceptions\CommandFailedException;
@@ -86,11 +87,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
   /**
    * Get all remote aliases from lagoon API.
-   *
-   * @command lagoon:aliases
-   *
-   * @aliases la
    */
+  #[CLI\Command(name: 'lagoon:aliases', aliases: ['la'])]
   public function aliases() {
     $this->preCommandChecks();
     // Project still not defined, throw a warning.
@@ -124,11 +122,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
   /**
    * Generate a JWT token for the lagoon API.
-   *
-   * @command lagoon:jwt
-   *
-   * @aliases jwt
    */
+  #[CLI\Command(name: 'lagoon:jwt', aliases: ['jwt'])]
   public function generateJwt() {
     $this->preCommandChecks();
     $this->io()->writeln($this->getJwtToken());
@@ -136,9 +131,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
   /**
    * Run pre-rollout tasks.
-   *
-   * @command lagoon:pre-rollout-tasks
    */
+  #[CLI\Command(name: 'lagoon:pre-rollout-tasks')]
   public function preRolloutTasks() {
     $this->preCommandChecks();
     $this->runRolloutTasks('pre');
@@ -146,9 +140,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
   /**
    * Run post-rollout tasks.
-   *
-   * @command lagoon:post-rollout-tasks
    */
+  #[CLI\Command(name: 'lagoon:post-rollout-tasks')]
   public function postRolloutTasks() {
     $this->preCommandChecks();
     $this->runRolloutTasks('post');

--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -4,8 +4,8 @@ namespace Drush\Commands\drupal_integrations;
 
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Commands\DrushCommands;
-use Drush\Exceptions\CommandFailedException;
 use Drush\Drush;
+use Drush\Exceptions\CommandFailedException;
 use Drush\SiteAlias\SiteAliasManagerAwareInterface;
 use GuzzleHttp\Client;
 use Symfony\Component\HttpKernel\Kernel;
@@ -65,8 +65,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * {@inheritdoc}
    */
   public function __construct() {
-    // Get default config
-    if($this->isLagoonEnvironment()) {
+    // Get default config.
+    if ($this->isLagoonEnvironment()) {
       $this->isLagoonEnvironment = TRUE;
       $lagoonyml = $this->getLagoonYml();
       $this->api = $lagoonyml['api'] ?? 'https://api.lagoon.amazeeio.cloud/graphql';
@@ -286,7 +286,7 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * @return void
    */
   private function preCommandChecks() {
-    if($this->isLagoonEnvironment() == FALSE) {
+    if ($this->isLagoonEnvironment() == FALSE) {
       throw new CommandFailedException(dt("Attempting to run a Lagoon command in a non-Lagoon environment."));
     }
   }

--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -274,6 +274,7 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
    * Will check whether the current environment is Lagoon or Lagoon dev envs.
    *
    * @return bool
+   *   is a functional Lagoon env
    */
   private function isLagoonEnvironment() {
     return !empty(getenv("LAGOON"));
@@ -281,9 +282,8 @@ class LagoonCommands extends DrushCommands implements SiteAliasManagerAwareInter
 
   /**
    * This should be run before any Lagoon commands.
-   * Checks whether we have a valid environment before running.
    *
-   * @return void
+   * Checks whether we have a valid environment before running.
    */
   private function preCommandChecks() {
     if ($this->isLagoonEnvironment() == FALSE) {

--- a/src/LagoonCommands.php
+++ b/src/LagoonCommands.php
@@ -4,7 +4,6 @@ namespace Drush\Commands\drupal_integrations;
 
 use Consolidation\SiteAlias\SiteAliasManagerAwareTrait;
 use Drush\Commands\DrushCommands;
-use Drush\Exceptions\CommandFailedException;
 use Drush\Drush;
 use Drush\Exceptions\CommandFailedException;
 use Drush\SiteAlias\SiteAliasManagerAwareInterface;


### PR DESCRIPTION
closes #25 

This PR replaces annotations with PHP attributes, as recommended in the Drush documentation.

Built on top of changes in #24 - can be merged after that.