### PR TITLE
Sets minimum drush version to 11.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "drupal/lagoon_logs": "Zero configuration logging system for Drupal sites running on Lagoon"
     },
     "require": {
-        "drupal/core-composer-scaffold": "*"
+        "drupal/core-composer-scaffold": "*",
+        "drush/drush": ">=11.6.0"
     }
 }


### PR DESCRIPTION
In order to support future implementations with, for instance, the `create()` function to deal with DI, we need to specify a higher minimum version of Drush