### PR TITLE
Explicitly set charset and collation for Drupal sites

### DIFF
--- a/assets/settings.lagoon.php
+++ b/assets/settings.lagoon.php
@@ -30,6 +30,8 @@ if (!defined("LAGOON_VERSION")) {
 }
 
 // Lagoon database connection.
+// If you require a specific charset or collation for your site, 
+// copy, update and add this paragraph to your all.settings.php file.
 if (getenv('LAGOON')) {
   $databases['default']['default'] = [
     'driver' => 'mysql',
@@ -38,6 +40,8 @@ if (getenv('LAGOON')) {
     'password' => getenv('MARIADB_PASSWORD') ?: 'drupal',
     'host' => getenv('MARIADB_HOST') ?: 'mariadb',
     'port' => getenv('MARIADB_PORT') ?: 3306,
+    'charset' => 'utf8mb4',
+    'collation' => 'utf8mb4_general_ci',
     'prefix' => '',
   ];
 }

--- a/assets/settings.lagoon.php
+++ b/assets/settings.lagoon.php
@@ -30,7 +30,7 @@ if (!defined("LAGOON_VERSION")) {
 }
 
 // Lagoon database connection.
-// If you require a specific charset or collation for your site, 
+// If you require a specific charset or collation for your site,
 // copy, update and add this paragraph to your all.settings.php file.
 if (getenv('LAGOON')) {
   $databases['default']['default'] = [
@@ -40,8 +40,8 @@ if (getenv('LAGOON')) {
     'password' => getenv('MARIADB_PASSWORD') ?: 'drupal',
     'host' => getenv('MARIADB_HOST') ?: 'mariadb',
     'port' => getenv('MARIADB_PORT') ?: 3306,
-    'charset' => 'utf8mb4',
-    'collation' => 'utf8mb4_general_ci',
+    'charset' => getenv('MARIADB_CHARSET') ?: 'utf8mb4',
+    'collation' => getenv('MARIADB_COLLATION') ?: 'utf8mb4_general_ci',
     'prefix' => '',
   ];
 }


### PR DESCRIPTION
Currently, Drupal only specifies a default charset to use (utfmb4) - this means that the table collation is chosen by the server default for utf8mb4 (not the database default) - as per https://dev.mysql.com/doc/refman/8.0/en/charset-table.html

This PR sets a sensible default charset and collation that should suit most uses, and be compatible with mariadb and MySQL installs. If your site requires additional configuration in the charset or collation, the entire paragraph should be replicated into your git config, and updated in the /assets/all.settings.php file

Note that this will not tables in an existing install, but will apply to new tables created (either a fresh install or an updb)

e.g to use the esperanto-specific collation:
```
if (getenv('LAGOON')) {
  $databases['default']['default'] = [
    'driver' => 'mysql',
    'database' => getenv('MARIADB_DATABASE') ?: 'drupal',
    'username' => getenv('MARIADB_USERNAME') ?: 'drupal',
    'password' => getenv('MARIADB_PASSWORD') ?: 'drupal',
    'host' => getenv('MARIADB_HOST') ?: 'mariadb',
    'port' => getenv('MARIADB_PORT') ?: 3306,
    'charset' => 'utf8mb4',
    'collation' => 'utf8mb4_esperanto_ci',
    'prefix' => '',
  ];
}
```